### PR TITLE
MRG: add `use-column` to pairwise_to_matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_betterplot"
 description = "sourmash plugin for improved plotting/viz and cluster examination."
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.4.1"
+version = "0.4.2"
 
 dependencies = ["sourmash>=4.8.8,<5", "sourmash_utils>=0.2",
                 "matplotlib", "numpy", "scipy", "scikit-learn",

--- a/src/sourmash_plugin_betterplot.py
+++ b/src/sourmash_plugin_betterplot.py
@@ -515,6 +515,12 @@ class Command_PairwiseToMatrix(CommandLinePlugin):
         )
         subparser.add_argument("-o", "--output-matrix", required=True)
         subparser.add_argument("--labels-to")
+        subparser.add_argument(
+            "-u",
+            "--use-column",
+            default="jaccard",
+            help="column name to use in matrix (default: jaccard)",
+        )
 
     def main(self, args):
         super().main(args)
@@ -527,6 +533,7 @@ class Command_PairwiseToMatrix(CommandLinePlugin):
         notify(f"loaded {len(rows)} rows containing {len(sample_d)} distinct samples")
 
         mat = numpy.zeros((len(sample_d), len(sample_d)))
+        colname = args.use_column
 
         for row in rows:
             # get unique indices for each query/match pair.
@@ -534,7 +541,7 @@ class Command_PairwiseToMatrix(CommandLinePlugin):
             qi = sample_d[q]
             m = row["match_name"]
             mi = sample_d[m]
-            jaccard = float(row["jaccard"])
+            jaccard = float(row[colname])
 
             mat[qi, mi] = jaccard
             mat[mi, qi] = jaccard


### PR DESCRIPTION
bumps version to 0.4.2, too.