### PR TITLE
MRG: support red, green, blue on ANI plot; fix upset stuff; bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_betterplot"
 description = "sourmash plugin for improved plotting/viz and cluster examination."
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.4.3"
+version = "0.4.4"
 
 dependencies = ["sourmash>=4.8.8,<5", "sourmash_utils>=0.2",
                 "matplotlib", "numpy", "scipy", "scikit-learn",

--- a/src/sourmash_plugin_betterplot.py
+++ b/src/sourmash_plugin_betterplot.py
@@ -1552,7 +1552,7 @@ against average abund for significant matches.
             notify(f"{len(df2)} matches to {args.green_color} => green circles")
             dfs.append(df2)
             colors.append('go')
-         if args.red_color:
+        if args.red_color:
             df2 = df[df['match_name'].str.contains(args.red_color)]
             notify(f"{len(df2)} matches to {args.red_color} => red crosses")
 


### PR DESCRIPTION
This:
```
for i in *.csv  
do                
sourmash scripts presence_filter $i --red Bacteroides --green Alist -o $(basename $i .csv).ani.png --blue Rumin --ani
done
```
produced this:

![SRR7947181 x gtdb-rs214 ani](https://github.com/user-attachments/assets/45c2950e-af30-40d4-b9e3-b2f37d649450)
