### PR TITLE
MRG: use regular miniforge (not mambaforge) for ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,6 @@ jobs:
         auto-update-conda: true
         python-version: 3.12
         channels: conda-forge,bioconda
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
         mamba-version: "*"


### PR DESCRIPTION
(Mambaforge no longer in service, ci fails otherwise)