### PR TITLE
MRG: add remaining dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_betterplot"
 description = "sourmash plugin for improved plotting/viz and cluster examination."
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 # note: "legacy_cgi" is currently needed for ete3, but may need to be changed on next ete release, see: https://github.com/etetoolkit/ete/issues/780
 dependencies = ["sourmash>=4.9.2,<5", "sourmash_utils>=0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,16 @@ readme = "README.md"
 requires-python = ">=3.10"
 version = "0.5.0"
 
-dependencies = ["sourmash>=4.8.8,<5", "sourmash_utils>=0.2",
+# note: "legacy_cgi" is currently needed for ete3, but may need to be changed on next ete release, see: https://github.com/etetoolkit/ete/issues/780
+dependencies = ["sourmash>=4.9.2,<5", "sourmash_utils>=0.2",
                 "matplotlib", "numpy", "scipy", "scikit-learn",
-                "seaborn", "upsetplot", "matplotlib_venn", "pandas", "plotly", "biopython", "ete3"]
+                "seaborn", "upsetplot", "matplotlib_venn", "pandas",
+                "plotly", "biopython", "ete3", "kaleido", "pyqt5",
+                "legacy_cgi"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [metadata]
 license = { text = "BSD 3-Clause License" }


### PR DESCRIPTION
- fixes #69 #63 #64 

adds the following dependencies needed for the `sankey` and `tree` commands:

For `sankey` (plotly):
- `kaleido`

For `tree`(ete3):
- `pyqt5` 
- `legacy_cgi`

`ete3` and `plotly` were already on the dependency list.

Note: We install `legacy_cgi` here because `ete3` still requires the `cgi` module, but it was deprecated in py 3.11 and removed in py 3.13. Installing `legacy_cgi` seems to work even with py 3.13.

There is an open PR in the ete repo to replace this dependency. The fix replaces `cgi` import with use of `from urllib.parse import parse_qs`, which means maybe we can just eliminate this from dependencies when it's in. See: https://github.com/etetoolkit/ete/issues/780