### PR TITLE
WIP: upd ete

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - sourmash>=4.8.8,<5
-    - sourmash_plugin_branchwater>=0.9.7
+    - sourmash>=4.9.2,<5
+    - sourmash_plugin_branchwater>=0.9.13,<1
     - pip
     - pytest
     - matplotlib
@@ -17,6 +17,6 @@ dependencies:
     - seaborn
     - plotly
     - biopython
-    - ete3>=3.1.3,<4
+    - ete4>=4.3.0,<5
     - pip:
       - kaleido

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,16 @@ readme = "README.md"
 requires-python = ">=3.10"
 version = "0.5.0"
 
-dependencies = ["sourmash>=4.8.8,<5", "sourmash_utils>=0.2",
+# note: "legacy_cgi" is currently needed for ete3, but may need to be changed on next ete release, see: https://github.com/etetoolkit/ete/issues/780
+dependencies = ["sourmash>=4.9.2,<5", "sourmash_utils>=0.2",
                 "matplotlib", "numpy", "scipy", "scikit-learn",
-                "seaborn", "upsetplot", "matplotlib_venn", "pandas", "plotly", "biopython", "ete3"]
+                "seaborn", "upsetplot", "matplotlib_venn", "pandas",
+                "plotly", "biopython", "ete3", "kaleido", "pyqt5",
+                "legacy_cgi"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [metadata]
 license = { text = "BSD 3-Clause License" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.5.0"
 dependencies = ["sourmash>=4.9.2,<5", "sourmash_utils>=0.2",
                 "matplotlib", "numpy", "scipy", "scikit-learn",
                 "seaborn", "upsetplot", "matplotlib_venn", "pandas",
-                "plotly", "biopython", "ete3", "kaleido", "pyqt5",
+                "plotly", "biopython", "ete4", "kaleido", "pyqt6",
                 "legacy_cgi"]
 
 [build-system]


### PR DESCRIPTION
- update to ete4, pyqt6

primary goal is to see if these fix the pip install issues on fresh linux instances. These are related to `pyqt5` pip install due to a missing library (solved by `sudo apt-get install -y libgl1`)